### PR TITLE
Aggregate the mesh indices for each prim, rather than just the last one

### DIFF
--- a/Assets/Scripts/Runtime/NodeGraphRunner.cs
+++ b/Assets/Scripts/Runtime/NodeGraphRunner.cs
@@ -66,9 +66,9 @@ namespace MiniDini.Runner
                     pointslist.Add(p.position);
 				}
                 mesh.vertices = pointslist.ToArray();
+                List<int> indexlist = new List<int>();
                 foreach(Prim pr in geom.prims)
 				{
-                    List<int> indexlist = new List<int>();
                     // triangle prims are simply added to the list of point indices for each tri
                     if (pr.points.Count == 3)
 					{
@@ -85,10 +85,10 @@ namespace MiniDini.Runner
                         indexlist.Add(pr.points[3]);
 
                     }
-                    mesh.triangles = indexlist.ToArray();
 				}
 
-			}
+                mesh.triangles = indexlist.ToArray();
+            }
 
         }
 


### PR DESCRIPTION
I have been attempting to complete the grid node task and I have stumbled into a potential bug. The indexList is being reset on each iteration of a geometry's primitive when aggregating the mesh indices.  When the `indexList `construction is moved out of the foreach loop and the `mesh.triangles` assignment is moved out of the foreach loop my grid renders as expected.
