### PR TITLE
Create node on graph at cursor position

### DIFF
--- a/Assets/Scripts/Editor/Views/UIBuilder/NodeGraphView.cs
+++ b/Assets/Scripts/Editor/Views/UIBuilder/NodeGraphView.cs
@@ -178,11 +178,12 @@ namespace MiniDini.Editor.Views
         /// Create a new <see cref="Node"/> with a Node View.
         /// </summary>
         /// <param name="type">The Type of Node to create.</param>
-        private void CreateNode(Type type)
+        /// <param name="initialPosition">The initial position of the Node on the graph when created.</param>
+        private void CreateNode(Type type, Vector2 initialPosition)
         {
             if (!m_graph) return;
 
-            Node node = m_graph.CreateNode(type);
+            Node node = m_graph.CreateNode(type, initialPosition);
             CreateNodeView(node);
             Undo.RecordObject(m_graph, "Node Graph (Create Node)");
 
@@ -231,12 +232,13 @@ namespace MiniDini.Editor.Views
         /// <param name="evt">The (<a href="https://docs.unity3d.com/2021.3/Documentation/ScriptReference/UIElements.ContextualMenuPopulateEvent.html" rel="external">UnityEngine.UIElements.ContextualMenuPopulateEvent</a>) event holding the menu to populate.</param>
         public override void BuildContextualMenu(ContextualMenuPopulateEvent evt)
         {
+            Vector2 mousePosition = evt.localMousePosition;
             TypeCache.TypeCollection types = TypeCache.GetTypesDerivedFrom<Node>();
             foreach (Type type in types)
             {
                 if (type.IsAbstract) continue;
                 evt.menu.AppendAction($"{type.BaseType.Name}/{type.Name}",
-                                      _ => CreateNode(type));
+                                      _ => CreateNode(type, mousePosition));
             }
 
             base.BuildContextualMenu(evt);

--- a/Assets/Scripts/Editor/Views/UIBuilder/NodeGraphView.cs
+++ b/Assets/Scripts/Editor/Views/UIBuilder/NodeGraphView.cs
@@ -232,7 +232,10 @@ namespace MiniDini.Editor.Views
         /// <param name="evt">The (<a href="https://docs.unity3d.com/2021.3/Documentation/ScriptReference/UIElements.ContextualMenuPopulateEvent.html" rel="external">UnityEngine.UIElements.ContextualMenuPopulateEvent</a>) event holding the menu to populate.</param>
         public override void BuildContextualMenu(ContextualMenuPopulateEvent evt)
         {
-            Vector2 mousePosition = evt.localMousePosition;
+            // View transform is positioned and scaled when the user drags or zooms the grid.
+            // So Convert the local (screen) mouse position to the entire graphs (world) position.
+            Vector3 mousePosition = viewTransform.matrix.inverse.MultiplyPoint(evt.localMousePosition);
+
             TypeCache.TypeCollection types = TypeCache.GetTypesDerivedFrom<Node>();
             foreach (Type type in types)
             {

--- a/Assets/Scripts/Runtime/NodeGraph.cs
+++ b/Assets/Scripts/Runtime/NodeGraph.cs
@@ -42,11 +42,12 @@ namespace MiniDini
         /// Create a new Node and add it to the nodes.
         /// </summary>
         /// <param name="type">The Type of Node to create.</param>
-        public Node CreateNode(System.Type type)
+        public Node CreateNode(System.Type type, Vector2 initalPosition)
         {
             Node node = CreateInstance(type) as Node;
             node.name = type.Name;
             node.guid = GUID.Generate().ToString();
+            node.nodeGraphPosition = initalPosition;
 
             nodes.Add(node);
 


### PR DESCRIPTION
Create node on graph at cursor position rather than at 0,0. This improves workflow when creating graphs as currently, a node is created at 0,0 which then needs to be moved to the desired location. When creating large graphs this becomes tedious and sometimes confusing. This commit will create it at the desired location (where the mouse pointer is) on the graph, removing the annonyance of scrolling back to 0,0 to move the node where the user originally wanted it. 