### PR TITLE
Add methods for merging and transforming geometries

### DIFF
--- a/Assets/Scripts/Runtime/Geometry/Geometry.cs
+++ b/Assets/Scripts/Runtime/Geometry/Geometry.cs
@@ -88,12 +88,30 @@ namespace MiniDini
 			Merge(copy);
 		}
 
+		// roate all points in the geometry by the given quaternion
+		public void Rotate(Vector3 rotation)
+		{
+			foreach (Point p in points)
+			{
+				p.position = Quaternion.Euler(rotation) * p.position;
+			}
+		}
+
 		// translate all points in the geometry by the given vector
 		public void Translate(Vector3 offset)
 		{
 			foreach (Point p in points)
 			{
 				p.position += offset;
+			}
+		}
+
+		// scale all points in the geometry by the given quaternion
+		public void Scale(Vector3 scale)
+		{
+			foreach (Point p in points)
+			{
+				p.position = Vector3.Scale(p.position, scale);
 			}
 		}
 		

--- a/Assets/Scripts/Runtime/Geometry/Geometry.cs
+++ b/Assets/Scripts/Runtime/Geometry/Geometry.cs
@@ -28,12 +28,17 @@ namespace MiniDini
 			points.Clear();
 			prims.Clear();
 
+			Merge(other);
+		}
+
+		// merge other geometry into this one without clearing
+		public void Merge(Geometry other)
+		{
 			foreach (Point p in other.points)
 			{
 				Point pn = new Point(p);
 				points.Add(pn);
 			}
-			//points.AddRange(other.points);
 			foreach (Prim pr in other.prims)
 			{
 				Prim prn = new Prim(pr);
@@ -76,18 +81,16 @@ namespace MiniDini
 		{
 			Geometry copy = new Geometry(other);
 			Empty();
-			foreach(Point p in copy.points)
+			Merge(copy);
+		}
+
+		// translate all points in the geometry by the given vector
+		public void Translate(Vector3 offset)
+		{
+			foreach (Point p in points)
 			{
-				Point pn = new Point(p);
-				points.Add(pn);
+				p.position += offset;
 			}
-			//points.AddRange(other.points);
-			foreach(Prim pr in copy.prims)
-			{
-				Prim prn = new Prim(pr);
-				prims.Add(prn);
-			}
-			//prims.AddRange(other.prims);
 		}
 		
 		// for debugging

--- a/Assets/Scripts/Runtime/Geometry/Geometry.cs
+++ b/Assets/Scripts/Runtime/Geometry/Geometry.cs
@@ -18,15 +18,13 @@ namespace MiniDini
 
 		public Geometry()
 		{
-			points.Clear();
-			prims.Clear();
+			Empty();
 		}
 
 		// copy constructor (theoretically makes a deep copy!)
 		public Geometry(Geometry other)
 		{
-			points.Clear();
-			prims.Clear();
+			Empty();
 
 			Merge(other);
 		}
@@ -34,6 +32,7 @@ namespace MiniDini
 		// merge other geometry into this one without clearing
 		public void Merge(Geometry other)
 		{
+			var initial_point_count = points.Count;
 			foreach (Point p in other.points)
 			{
 				Point pn = new Point(p);
@@ -42,6 +41,11 @@ namespace MiniDini
 			foreach (Prim pr in other.prims)
 			{
 				Prim prn = new Prim(pr);
+				for (int i = 0; i < prn.points.Count; i++)
+				{
+					// offset the point indices so they're not pointing to previously existing points
+					prn.points[i] += initial_point_count;
+				}
 				prims.Add(prn);
 			}
 		}

--- a/Assets/Scripts/Runtime/Geometry/Prim.cs
+++ b/Assets/Scripts/Runtime/Geometry/Prim.cs
@@ -30,7 +30,7 @@ namespace MiniDini
 		{
             points.Clear();
             normal = p.normal;
-            points = p.points;
+            points = new List<int>(p.points);
             selected = p.selected;
         }
 
@@ -39,12 +39,10 @@ namespace MiniDini
             points.Clear();
             Prim p = new Prim();
             p.normal = normal;
-            p.points = points;
+            p.points = new List<int>(points);
             p.selected = selected;
             return p;
         }
     }
-
-
 
 }


### PR DESCRIPTION
Added methods for merging and transforming geometries for quality of life and potential use in operation nodes. Additionally, fix the Prim Copy constructor to ensure that its points list is cloned instead of still referencing the original.