### PR TITLE
Noise grid (heightmap) node - Andrejs Krauze 25089026

### DIFF
--- a/Assets/Scripts/Runtime/Nodes/Geometry/NoiseGridNode.cs
+++ b/Assets/Scripts/Runtime/Nodes/Geometry/NoiseGridNode.cs
@@ -1,0 +1,42 @@
+
+using System.Collections.Generic;
+using System;
+using UnityEngine;
+
+namespace MiniDini.Nodes
+{
+    /// <summary>
+    /// <see cref="Node"/> that has a list of children.
+    /// </summary>
+    [System.Serializable]
+    public class NoiseGridNode : GridNode
+    {
+        #region Overrides of Node
+
+        public override string GetDescription() { return "A noisy grid (heightmap) made of NxM quads"; }
+
+        [SerializeField]
+        [Range(0.1f, 9.0f)]
+        public float frequency = 3.0f;
+
+        [SerializeField]
+        [Range(0.1f, 10.0f)]
+        public float strength = 1.0f;
+
+        /// <summary>
+        /// Get the geometry for this Node.
+        /// </summary>
+        /// <returns>A geometry object</returns>
+        public override Geometry GetGeometry()
+        {
+            m_geometry = base.GetGeometry();
+
+            // offset the grid points by a noise value here
+
+            return m_geometry;
+        }
+
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Runtime/Nodes/Geometry/NoiseGridNode.cs
+++ b/Assets/Scripts/Runtime/Nodes/Geometry/NoiseGridNode.cs
@@ -6,7 +6,13 @@ using UnityEngine;
 namespace MiniDini.Nodes
 {
     /// <summary>
-    /// <see cref="Node"/> that has a list of children.
+    /// <see cref="Node"/>
+    /// This is a grid of quads with points' z values offset by a noise value.
+    /// This is a good way to make a heightmap, or a terrain.
+    /// It can also be fed into a CopyToPoints node to randomise the position of objects.
+    /// The noise value is based on the x and y coordinates of the grid.
+    /// It is generated using the Perlin noise function.
+    /// The noise value is scaled by the frequency and strength fields.
     /// </summary>
     [System.Serializable]
     public class NoiseGridNode : GridNode

--- a/Assets/Tests/EditMode/NoiseGridNodeTests.cs
+++ b/Assets/Tests/EditMode/NoiseGridNodeTests.cs
@@ -1,0 +1,87 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using MiniDini.Nodes;
+using MiniDini;
+
+public class NoiseGridNodeTests
+{
+    static NoiseGridNode gridnode = null;
+    static Geometry geom = null;
+
+    static void MakeNodeAndGeometry()
+    {
+        if (gridnode == null)
+		{
+            gridnode = (NoiseGridNode)ScriptableObject.CreateInstance<NoiseGridNode>();
+            gridnode.width = 10;
+            gridnode.height = 10;
+            gridnode.rows = 10;
+            gridnode.columns = 10;
+            gridnode.frequency = 8.0f;
+            gridnode.strength = 5.0f;
+        }
+
+        if (geom == null)
+            geom = gridnode.GetGeometry();
+    }
+
+    [Test]
+    public void GridNodeIsNotNull()
+    {
+        MakeNodeAndGeometry();
+
+        Assert.NotNull(gridnode, "Quad Node must not be null");
+    }
+    [Test]
+    public void GridNodeGeometryIsNotNull()
+    {
+        MakeNodeAndGeometry();
+
+        Assert.NotNull(geom, "Geometry must not be null");
+    }
+    
+    // we do not have to test the validity of the grid itself since that code is inherited from the GridNode
+
+    [Test]
+    public void NoiseGridNodeIsNotFlat()
+    {
+        MakeNodeAndGeometry();
+        
+        // simply check that the z values are not all the same
+        var first_z = geom.points[0].position.z;
+        bool flag = false;
+        foreach (var point in geom.points)
+        {
+            if (point.position.z != first_z)
+            {
+                flag = true;
+                break;
+            }
+        }
+        Assert.True(flag, $"Grid must not be flat (all points should have randomised z values)");
+    }
+
+
+    [Test]
+    public void NoiseGridNodeIsWellDistributed()
+    {
+        MakeNodeAndGeometry();
+
+        // calculate the average z value
+        float avg_z = 0.0f;
+        foreach (var point in geom.points)
+        {
+            avg_z += point.position.z;
+        }
+        avg_z /= geom.points.Count;
+
+        // check that the average z value is not too far from 0, accounting for the strength of the noise
+        avg_z -= gridnode.strength / 2.0f;
+        Assert.True(Mathf.Abs(avg_z) < 0.5f, $"Grid must be well distributed (average z value should be close to 0), average_z = {avg_z}");
+    }
+
+
+}


### PR DESCRIPTION
This is the pull request by Andrejs Krauze (25089026) to implement a noisy grid node, which generates a grid of quads whose points are offset by a random value. The strength and the frequency of the noise can be adjusted, in addition to the parameters such as rows and columns inherited from the original grid node. This can be used to generate a terrain, or fed into a copy to points node to create objects at randomised heights. 
The complete implementation of the node that passes the tests is available in my [private fork](https://github.com/aaf6aa/UnitTest).